### PR TITLE
Add OpenRouter Support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # NanoThumbnail
 
-NanoThumbnail is a free, open-source web application designed to create viral YouTube thumbnails using AI. It supports two providers: **Replicate** (Google Nano Banana Pro model) and **Google Gemini** (gemini-3-pro-image-preview) to transform simple prompts into high-quality, expressive images.
+NanoThumbnail is a free, open-source web application designed to create viral YouTube thumbnails using AI. It supports three providers: **Replicate** (Google Nano Banana Pro model), **Google Gemini** (gemini-3-pro-image-preview), and **OpenRouter** (gemini-3-pro-image-preview) to transform simple prompts into high-quality, expressive images.
 
 ![NanoThumbnail Preview](image.webp)
 
 ## Features
 
 -   **Nano Banana Pro Integration**: Uses Google's latest model, optimized for text rendering and photorealism.
--   **BYOK (Bring Your Own Key)**: Connect your own Replicate or Google Gemini API key. You pay the provider directly, ensuring privacy and the lowest cost.
+-   **BYOK (Bring Your Own Key)**: Connect your own Replicate, Google Gemini API key or OpenRouter API key. You pay the provider directly, ensuring privacy and the lowest cost.
 -   **100% Free Interface**: No monthly subscriptions or hidden fees for the UI.
 -   **Reference Images**: Upload up to 14 reference images to guide the AI generation.
 -   **Customizable Output**: Configure resolution (1K/2K/4K), aspect ratio (16:9, 9:16, 4:3, 1:1), output format (PNG/JPG), and safety filter level.
@@ -22,7 +22,7 @@ NanoThumbnail is a free, open-source web application designed to create viral Yo
 -   **Styling**: Custom CSS with Glassmorphism UI
 -   **Icons**: Font Awesome
 -   **Font**: Plus Jakarta Sans (Google Fonts)
--   **API**: [Replicate](https://replicate.com/) (Google Nano Banana Pro model) or [Google Gemini](https://aistudio.google.com/) (gemini-3-pro-image-preview)
+-   **API**: [Replicate](https://replicate.com/) (Google Nano Banana Pro model) or [Google Gemini](https://aistudio.google.com/) (gemini-3-pro-image-preview) or [OpenRouter](https://openrouter.ai/) (gemini-3-pro-image-preview)
 -   **CORS Proxy**: [corsproxy.io](https://corsproxy.io/)
 -   **Hosting**: [Netlify](https://netlify.com/)
 
@@ -57,7 +57,7 @@ src/
 │   ├── privacy-policy.astro
 │   └── terms-of-service.astro
 ├── scripts/
-│   ├── api.ts               # Replicate/Gemini API integration & polling
+│   ├── api.ts               # Replicate/Gemini/OpenRouter API integration & polling
 │   ├── state.ts             # Application state management
 │   ├── ui.ts                # UI logic (history, image upload, settings)
 │   ├── i18n/                # Internationalization
@@ -78,7 +78,7 @@ src/
 
 -   Node.js (v18 or higher)
 -   npm
--   A [Replicate](https://replicate.com/) API key and/or a [Google Gemini](https://aistudio.google.com/apikey) API key
+-   A [Replicate](https://replicate.com/) API key and/or a [Google Gemini](https://aistudio.google.com/apikey) API key and/or an [OpenRouter](https://openrouter.ai/) API key
 
 ### Installation
 
@@ -125,8 +125,8 @@ The project is configured for deployment on **Netlify** with the `netlify.toml` 
 1. **User enters a prompt** describing the desired thumbnail
 2. **Optional**: Upload reference images to guide the generation
 3. **Configure settings**: resolution, aspect ratio, format, safety level
-4. **API call**: The prompt is enhanced and sent to Replicate (Nano Banana Pro) or Google Gemini, depending on the selected provider
-5. **Polling** (Replicate only): The app polls the API until the generation is complete. Gemini returns the image in a single request
+4. **API call**: The prompt is enhanced and sent to Replicate (Nano Banana Pro), Google Gemini, or OpenRouter, depending on the selected provider
+5. **Polling** (Replicate only): The app polls the API until the generation is complete. Gemini and OpenRouter return the image in a single request
 6. **Display**: The generated image is fetched via CORS proxy and displayed
 7. **Download**: User can download the thumbnail in the selected format
 

--- a/netlify/functions/replicate-proxy.ts
+++ b/netlify/functions/replicate-proxy.ts
@@ -3,6 +3,7 @@ import type { Handler, HandlerEvent } from '@netlify/functions';
 const ALLOWED_ORIGINS = [
   'https://api.replicate.com',
   'https://generativelanguage.googleapis.com',
+  'https://openrouter.ai',
 ];
 
 const corsHeaders = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4260,6 +4260,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -4577,6 +4578,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4925,6 +4927,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5090,6 +5093,7 @@
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -5153,6 +5157,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/app/MainArea.astro
+++ b/src/components/app/MainArea.astro
@@ -47,13 +47,28 @@
         flex-direction: column;
     }
 
-    .result-placeholder {
-        color: var(--text-muted);
-        font-size: 1.2rem;
+      .result-placeholder {
         display: flex;
         flex-direction: column;
         align-items: center;
         gap: 1rem;
+        justify-content: center;
+        height: 100%;
+        padding: 2rem;
+        color: rgba(255, 255, 255, 0.4);
+        font-size: 0.9rem;
+      }
+
+      .result-placeholder.hidden {
+        display: none;
+      }
+
+    .result-placeholder.hidden {
+        display: none !important;
+    }
+
+    .generated-image.hidden {
+        display: none !important;
     }
 
     .generated-image {
@@ -72,7 +87,16 @@
         gap: 10px;
     }
 
-    .actions-bar.hidden {
+    .actions-bar.hidden,
+    .result-placeholder.hidden {
+        display: none;
+    }
+
+    .result-placeholder.hidden {
+        display: none;
+    }
+
+    .generated-image.hidden {
         display: none;
     }
 

--- a/src/components/app/SettingsModal.astro
+++ b/src/components/app/SettingsModal.astro
@@ -11,6 +11,7 @@ import GlassPanel from '../ui/GlassPanel.astro';
             <select id="providerSelect" class="input-field">
                 <option value="replicate">Replicate</option>
                 <option value="gemini">Google Gemini</option>
+                <option value="openrouter">OpenRouter</option>
             </select>
         </div>
         <div id="replicateKeyGroup" class="input-group">
@@ -29,6 +30,15 @@ import GlassPanel from '../ui/GlassPanel.astro';
             <a href="https://aistudio.google.com/apikey" target="_blank" rel="noopener noreferrer" class="api-link">
                 <i class="fa-solid fa-external-link-alt"></i>
                 <span data-i18n="modals.get_api_key_gemini">Obtenir une clé API Google AI</span>
+            </a>
+        </div>
+        <div id="openrouterKeyGroup" class="input-group hidden">
+            <label data-i18n="modals.label_api_openrouter">OpenRouter API Key</label>
+            <input type="password" id="apiKeyOpenRouterInput" class="input-field" placeholder="sk-or-...">
+            <small data-i18n="modals.help_api">Stored locally in your browser.</small>
+            <a href="https://openrouter.ai/keys" target="_blank" rel="noopener noreferrer" class="api-link">
+                <i class="fa-solid fa-external-link-alt"></i>
+                <span data-i18n="modals.get_api_key_openrouter">Get an OpenRouter API Key</span>
             </a>
         </div>
         <div class="input-group checkbox-group">

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -103,6 +103,7 @@ export async function generateImage(): Promise<void> {
       const dataUri = await generateViaOpenRouter({
         prompt: enhancedPrompt,
         aspectRatio,
+        resolution,
         referenceImages: state.referenceImages,
       });
 

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -3,6 +3,7 @@ import { displayResult, addToHistory } from './ui';
 import { t } from './i18n/index';
 import { showErrorModal } from './modules/errors/handler';
 import { generateViaGemini } from './gemini';
+import { generateViaOpenRouter } from './openrouter';
 
 interface PredictionInput {
   prompt: string;
@@ -92,6 +93,29 @@ export async function generateImage(): Promise<void> {
         output_format: 'png',
         safety_filter_level: safety,
         provider: 'gemini',
+      };
+
+      await addToHistory(prompt, dataUri, dataUri, parameters);
+    } else if (state.provider === 'openrouter') {
+      // --- OPENROUTER: synchronous single-request flow ---
+      if (statusText) statusText.innerText = t('app.status_working');
+
+      const dataUri = await generateViaOpenRouter({
+        prompt: enhancedPrompt,
+        aspectRatio,
+        referenceImages: state.referenceImages,
+      });
+
+      if (statusText) statusText.innerText = t('app.status_download');
+
+      await displayResult(dataUri, prompt);
+
+      const parameters: GenerationParameters = {
+        resolution,
+        aspect_ratio: aspectRatio,
+        output_format: 'png',
+        safety_filter_level: safety,
+        provider: 'openrouter',
       };
 
       await addToHistory(prompt, dataUri, dataUri, parameters);

--- a/src/scripts/i18n/en.ts
+++ b/src/scripts/i18n/en.ts
@@ -16,7 +16,7 @@ export const en = {
     cta_start: "Start Now",
     cta_pricing: "See Pricing",
     badge_free: "Free (Interface)",
-    badge_byok: "BYOK (Replicate / Gemini)",
+    badge_byok: "BYOK (Replicate / Gemini / OpenRouter)",
     badge_new: "NEW",
     badge_new_desc: "Personas & Title Overlay",
     open_source: "Open Source. Today and Forever.",
@@ -26,7 +26,7 @@ export const en = {
     feature_2_title: "100% Free",
     feature_2_desc: "Our tool is a free and open-source interface. <strong>No hidden subscriptions</strong>, no commission on your creations. You only pay for what you consume.",
     feature_3_title: "Bring Your Own Key",
-    feature_3_desc: "Connect your <strong>Replicate</strong> or <strong>Google Gemini</strong> account directly. It's the guarantee of paying the real provider price and keeping full control over your data and API.",
+    feature_3_desc: "Connect your <strong>Replicate</strong>, <strong>Google Gemini</strong>, or <strong>OpenRouter</strong> account directly. It's the guarantee of paying the real provider price and keeping full control over your data and API.",
     feature_4_title: "Personas",
     feature_4_desc: "Create face profiles (left, front, right) and inject them as references. The AI faithfully reproduces <strong>your face</strong> in every thumbnail.",
     feature_5_title: "YouTube Remix",
@@ -54,7 +54,7 @@ export const en = {
       badge: "BEST OFFER",
       pay_per_use: "Pay as you go (~$0.14/img)",
       feature_1: "100% Free Interface",
-      feature_2: "Replicate or Gemini API Key (At cost)",
+      feature_2: "Replicate, Gemini, or OpenRouter API Key (At cost)",
       feature_3: "Privacy Respected (Local)",
       cta: "Start for Free",
       competitors_title: "SaaS Competitors",
@@ -80,7 +80,7 @@ export const en = {
     step_3_desc: "Download your thumbnail in PNG/JPG and upload it directly to YouTube.",
     faq_title: "Frequently Asked Questions",
     faq_1_q: "Is it really free?",
-    faq_1_a: "The NanoThumbnail interface is 100% free. However, image generation uses the Replicate or Google Gemini API which is paid (approx $0.14 per image on Replicate). You pay the provider directly.",
+    faq_1_a: "The NanoThumbnail interface is 100% free. However, image generation uses the Replicate, Google Gemini, or OpenRouter API which is paid (approx $0.14 per image on Replicate). You pay the provider directly.",
     faq_2_q: "Is my API key secure?",
     faq_2_a: "Yes. Your key is stored only in your browser (LocalStorage). It is never sent to our servers (we don't have any!).",
     faq_3_q: "Can I use images commercially?",
@@ -102,7 +102,7 @@ export const en = {
     },
     cta_final_title: "Ready to explode your CTR?",
     cta_final_btn: "Create my first thumbnail",
-    footer: "YoanDev - NanoThumbnail © 2025 • Powered by Replicate & Google Gemini"
+    footer: "YoanDev - NanoThumbnail © 2025 • Powered by Replicate, Google Gemini & OpenRouter"
   },
   app: {
     sidebar_idea: "1. Your Idea (Prompt)",
@@ -156,10 +156,12 @@ export const en = {
     label_api: "Replicate API Key",
     label_api_replicate: "Replicate API Key",
     label_api_gemini: "Google Gemini API Key",
+    label_api_openrouter: "OpenRouter API Key",
     help_api: "Stored locally in your browser.",
     get_api_key: "Get a Replicate API Key",
     get_api_key_replicate: "Get a Replicate API Key",
     get_api_key_gemini: "Get a Google AI API Key",
+    get_api_key_openrouter: "Get an OpenRouter API Key",
     label_save_locally: "Save images locally",
     help_save_locally: "Images will be stored in your browser to prevent expiration.",
     btn_cancel: "Cancel",
@@ -220,6 +222,6 @@ export const en = {
     col_product: "Product",
     col_resources: "Resources",
     col_legal: "Legal",
-    copyright: "YoanDev - NanoThumbnail © 2025 • Powered by Replicate & Google Gemini"
+    copyright: "YoanDev - NanoThumbnail © 2025 • Powered by Replicate, Google Gemini & OpenRouter"
   }
 };

--- a/src/scripts/i18n/fr.ts
+++ b/src/scripts/i18n/fr.ts
@@ -16,7 +16,7 @@ export const fr = {
     cta_start: "Commencer maintenant",
     cta_pricing: "Voir les prix",
     badge_free: "Gratuit (Interface)",
-    badge_byok: "BYOK (Replicate / Gemini)",
+    badge_byok: "BYOK (Replicate / Gemini / OpenRouter)",
     badge_new: "NOUVEAU",
     badge_new_desc: "Personas & Titre sur vos miniatures",
     open_source: "Open Source. Aujourd'hui et pour toujours.",
@@ -26,7 +26,7 @@ export const fr = {
     feature_2_title: "100% Gratuit",
     feature_2_desc: "Notre outil est une interface gratuite et open-source. <strong>Aucun abonnement caché</strong>, aucune commission sur vos créations. Vous ne payez que ce que vous consommez.",
     feature_3_title: "Bring Your Own Key",
-    feature_3_desc: "Connectez directement votre compte <strong>Replicate</strong> ou <strong>Google Gemini</strong>. C'est la garantie de payer le prix réel fournisseur et de garder le contrôle total sur vos données et votre API.",
+    feature_3_desc: "Connectez directement votre compte <strong>Replicate</strong>, <strong>Google Gemini</strong>, ou <strong>OpenRouter</strong>. C'est la garantie de payer le prix réel fournisseur et de garder le contrôle total sur vos données et votre API.",
     feature_4_title: "Personas",
     feature_4_desc: "Créez des profils visage (gauche, face, droite) et injectez-les comme références. L'IA reproduit fidèlement <strong>votre visage</strong> sur chaque miniature.",
     feature_5_title: "Remix YouTube",
@@ -54,7 +54,7 @@ export const fr = {
       badge: "MEILLEURE OFFRE",
       pay_per_use: "Payez à l'usage (~0.14€/img)",
       feature_1: "Interface 100% Gratuite",
-      feature_2: "Clé API Replicate ou Gemini (Prix coûtant)",
+      feature_2: "Clé API Replicate, Gemini, ou OpenRouter (Prix coûtant)",
       feature_3: "Vie privée respectée (Local)",
       cta: "Commencer Gratuitement",
       competitors_title: "Concurrents SaaS",
@@ -80,7 +80,7 @@ export const fr = {
     step_3_desc: "Téléchargez votre miniature en PNG/JPG et uploadez-la directement sur YouTube.",
     faq_title: "Questions Fréquentes",
     faq_1_q: "Est-ce vraiment gratuit ?",
-    faq_1_a: "L'interface NanoThumbnail est 100% gratuite. Cependant, la génération d'images utilise l'API Replicate ou Google Gemini qui est payante (environ 0.14$ par image sur Replicate). Vous payez directement le fournisseur.",
+    faq_1_a: "L'interface NanoThumbnail est 100% gratuite. Cependant, la génération d'images utilise l'API Replicate, Google Gemini, ou OpenRouter qui est payante (environ 0.14$ par image sur Replicate). Vous payez directement le fournisseur.",
     faq_2_q: "Ma clé API est-elle sécurisée ?",
     faq_2_a: "Oui. Votre clé est stockée uniquement dans votre navigateur (LocalStorage). Elle n'est jamais envoyée sur nos serveurs (nous n'en avons pas !).",
     faq_3_q: "Puis-je utiliser les images commercialement ?",
@@ -102,7 +102,7 @@ export const fr = {
     },
     cta_final_title: "Prêt à exploser votre CTR ?",
     cta_final_btn: "Créer ma première miniature",
-    footer: "YoanDev - NanoThumbnail © 2025 • Propulsé par Replicate & Google Gemini"
+    footer: "YoanDev - NanoThumbnail © 2025 • Propulsé par Replicate, Google Gemini & OpenRouter"
   },
   app: {
     sidebar_idea: "1. Votre Idée (Prompt)",
@@ -156,10 +156,12 @@ export const fr = {
     label_api: "Clé API Replicate",
     label_api_replicate: "Clé API Replicate",
     label_api_gemini: "Clé API Google Gemini",
+    label_api_openrouter: "Clé API OpenRouter",
     help_api: "Stockée localement dans votre navigateur.",
     get_api_key: "Obtenir une clé API Replicate",
     get_api_key_replicate: "Obtenir une clé API Replicate",
     get_api_key_gemini: "Obtenir une clé API Google AI",
+    get_api_key_openrouter: "Obtenir une clé API OpenRouter",
     label_save_locally: "Sauvegarder les images localement",
     help_save_locally: "Les images seront stockées dans votre navigateur pour éviter leur expiration.",
     btn_cancel: "Annuler",
@@ -222,6 +224,6 @@ export const fr = {
     col_product: "Produit",
     col_resources: "Ressources",
     col_legal: "Légal",
-    copyright: "YoanDev - NanoThumbnail © 2025 • Propulsé par Replicate & Google Gemini"
+    copyright: "YoanDev - NanoThumbnail © 2025 • Propulsé par Replicate, Google Gemini & OpenRouter"
   }
 };

--- a/src/scripts/openrouter.ts
+++ b/src/scripts/openrouter.ts
@@ -100,7 +100,7 @@ export async function generateViaOpenRouter(params: {
   const mappedSize = RESOLUTION_MAP[resolution] || "1K";
 
   const body = {
-    model: "black-forest-labs/flux.2-klein-4b",
+    model: "google/gemini-3-pro-image-preview",
     messages,
     modalities: ["image"],
     image_config: {

--- a/src/scripts/openrouter.ts
+++ b/src/scripts/openrouter.ts
@@ -1,0 +1,149 @@
+import { state } from "./state";
+import { t } from "./i18n/index";
+import { showErrorModal } from "./modules/errors/handler";
+
+interface OpenRouterMessage {
+  role: "user" | "assistant" | "system";
+  content: string;
+}
+
+interface OpenRouterResponse {
+  choices?: Array<{
+    message?: {
+      content?: string;
+    };
+  }>;
+  error?: { message: string; code: string };
+}
+
+const ASPECT_RATIO_MAP: Record<string, string> = {
+  "16:9": "16:9",
+  "9:16": "9:16",
+  "1:1": "1:1",
+  "4:3": "4:3",
+  match_input_image: "16:9", // Fallback — OpenRouter doesn't support match_input_image
+};
+
+export async function generateViaOpenRouter(params: {
+  prompt: string;
+  aspectRatio: string;
+  referenceImages: string[];
+}): Promise<string> {
+  const { prompt, aspectRatio, referenceImages } = params;
+
+  // Build messages array
+  const messages: OpenRouterMessage[] = [];
+
+  // System message with instructions
+  messages.push({
+    role: "system",
+    content:
+      "You are an image generation assistant. Generate high-quality YouTube thumbnails based on the user's prompt.",
+  });
+
+  // Build user content with text and images
+  let userContent = prompt;
+
+  // Add aspect ratio instruction
+  const mappedRatio = ASPECT_RATIO_MAP[aspectRatio] || "16:9";
+  userContent += `\n\nGenerate the image in ${mappedRatio} aspect ratio.`;
+
+  // Add reference images as data URIs
+  for (const img of referenceImages) {
+    // img is a data URI like "data:image/png;base64,..."
+    userContent += `\n\nReference image: ${img}`;
+  }
+
+  messages.push({
+    role: "user",
+    content: userContent,
+  });
+
+  const body = {
+    model: "black-forest-labs/flux.2-klein-4b",
+    messages,
+    response_format: {
+      type: "image",
+    },
+  };
+
+  // Call OpenRouter API directly (supports CORS)
+  const openRouterUrl = "https://openrouter.ai/api/v1/chat/completions";
+
+  const response = await fetch(openRouterUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${state.apiKey}`,
+      "HTTP-Referer":
+        typeof window !== "undefined"
+          ? window.location.origin
+          : "https://nanothumbnail.com",
+      "X-Title": "NanoThumbnail",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    let errorDetails: Record<string, unknown>;
+    try {
+      errorDetails = JSON.parse(errorText);
+    } catch {
+      errorDetails = { rawResponse: errorText };
+    }
+    showErrorModal({ statusCode: response.status, errorDetails });
+    throw new Error(
+      `${t("alerts.error_api")} (${response.status}): ${errorText}`,
+    );
+  }
+
+  const data: OpenRouterResponse = await response.json();
+
+  if (data.error) {
+    showErrorModal({
+      statusCode: 500,
+      errorDetails: data.error as unknown as Record<string, unknown>,
+    });
+    throw new Error(`${t("alerts.error_api")}: ${data.error.message}`);
+  }
+
+  // Extract image data from the response
+  const content = data.choices?.[0]?.message?.content;
+
+  if (!content) {
+    showErrorModal({
+      statusCode: 500,
+      errorDetails: {
+        message: "No image returned by OpenRouter",
+        response: data as unknown as Record<string, unknown>,
+      },
+    });
+    throw new Error(t("alerts.error_generation"));
+  }
+
+  // Check if content is already a data URI
+  if (content.startsWith("data:")) {
+    return content;
+  }
+
+  // Try to extract base64 data from markdown image format: ![alt](data:image/...;base64,...)
+  const markdownMatch = content.match(/!\[.*?\]\((data:image\/[^)]+)\)/);
+  if (markdownMatch) {
+    return markdownMatch[1];
+  }
+
+  // If content looks like base64, wrap it
+  if (/^[A-Za-z0-9+/=]+$/.test(content)) {
+    return `data:image/png;base64,${content}`;
+  }
+
+  showErrorModal({
+    statusCode: 500,
+    errorDetails: {
+      message: "Unexpected response format from OpenRouter",
+      response: data as unknown as Record<string, unknown>,
+    },
+  });
+  throw new Error(t("alerts.error_generation"));
+}

--- a/src/scripts/state.ts
+++ b/src/scripts/state.ts
@@ -1,6 +1,6 @@
 // Application state management
 
-export type ApiProvider = 'replicate' | 'gemini';
+export type ApiProvider = 'replicate' | 'gemini' | 'openrouter';
 
 export interface GenerationParameters {
   resolution: string;
@@ -23,6 +23,7 @@ export interface AppState {
   apiKey: string;
   apiKeyReplicate: string;
   apiKeyGemini: string;
+  apiKeyOpenRouter: string;
   proxyUrl: string;
   history: HistoryItem[];
   referenceImages: string[];
@@ -56,12 +57,26 @@ migrateApiKey();
 const provider = (localStorage.getItem('nano_provider') as ApiProvider) || 'replicate';
 const apiKeyReplicate = localStorage.getItem('nano_api_key_replicate') || '';
 const apiKeyGemini = localStorage.getItem('nano_api_key_gemini') || '';
+const apiKeyOpenRouter = localStorage.getItem('nano_api_key_openrouter') || '';
+
+function getActiveApiKey(): string {
+  switch (provider) {
+    case 'gemini':
+      return apiKeyGemini;
+    case 'openrouter':
+      return apiKeyOpenRouter;
+    case 'replicate':
+    default:
+      return apiKeyReplicate;
+  }
+}
 
 export const state: AppState = {
   provider,
-  apiKey: provider === 'gemini' ? apiKeyGemini : apiKeyReplicate,
+  apiKey: getActiveApiKey(),
   apiKeyReplicate,
   apiKeyGemini,
+  apiKeyOpenRouter,
   proxyUrl: '/.netlify/functions/replicate-proxy?url=',
   history: loadHistory(),
   referenceImages: [],

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -28,6 +28,7 @@ export function openSettings(): void {
   const providerSelect = document.getElementById('providerSelect') as HTMLSelectElement | null;
   const apiKeyReplicateInput = document.getElementById('apiKeyReplicateInput') as HTMLInputElement | null;
   const apiKeyGeminiInput = document.getElementById('apiKeyGeminiInput') as HTMLInputElement | null;
+  const apiKeyOpenRouterInput = document.getElementById('apiKeyOpenRouterInput') as HTMLInputElement | null;
   const saveLocallyCheckbox = document.getElementById('saveLocallyCheckbox') as HTMLInputElement | null;
   settingsModal = document.getElementById('settingsModal');
 
@@ -43,6 +44,9 @@ export function openSettings(): void {
   if (apiKeyGeminiInput) {
     apiKeyGeminiInput.value = state.apiKeyGemini;
   }
+  if (apiKeyOpenRouterInput) {
+    apiKeyOpenRouterInput.value = state.apiKeyOpenRouter;
+  }
   if (saveLocallyCheckbox) {
     saveLocallyCheckbox.checked = state.saveLocally;
   }
@@ -55,12 +59,20 @@ export function openSettings(): void {
 function toggleProviderKeyGroup(provider: ApiProvider): void {
   const replicateGroup = document.getElementById('replicateKeyGroup');
   const geminiGroup = document.getElementById('geminiKeyGroup');
+  const openrouterGroup = document.getElementById('openrouterKeyGroup');
+  
+  // Hide all groups first
+  replicateGroup?.classList.add('hidden');
+  geminiGroup?.classList.add('hidden');
+  openrouterGroup?.classList.add('hidden');
+  
+  // Show the appropriate group
   if (provider === 'gemini') {
-    replicateGroup?.classList.add('hidden');
     geminiGroup?.classList.remove('hidden');
+  } else if (provider === 'openrouter') {
+    openrouterGroup?.classList.remove('hidden');
   } else {
     replicateGroup?.classList.remove('hidden');
-    geminiGroup?.classList.add('hidden');
   }
 }
 
@@ -75,12 +87,27 @@ export function saveSettings(): void {
   const providerSelect = document.getElementById('providerSelect') as HTMLSelectElement | null;
   const apiKeyReplicateInput = document.getElementById('apiKeyReplicateInput') as HTMLInputElement | null;
   const apiKeyGeminiInput = document.getElementById('apiKeyGeminiInput') as HTMLInputElement | null;
+  const apiKeyOpenRouterInput = document.getElementById('apiKeyOpenRouterInput') as HTMLInputElement | null;
   const saveLocallyCheckbox = document.getElementById('saveLocallyCheckbox') as HTMLInputElement | null;
 
   const provider = (providerSelect?.value || 'replicate') as ApiProvider;
   const replicateKey = apiKeyReplicateInput?.value.trim() || '';
   const geminiKey = apiKeyGeminiInput?.value.trim() || '';
-  const activeKey = provider === 'gemini' ? geminiKey : replicateKey;
+  const openrouterKey = apiKeyOpenRouterInput?.value.trim() || '';
+  
+  let activeKey: string;
+  switch (provider) {
+    case 'gemini':
+      activeKey = geminiKey;
+      break;
+    case 'openrouter':
+      activeKey = openrouterKey;
+      break;
+    case 'replicate':
+    default:
+      activeKey = replicateKey;
+      break;
+  }
 
   if (!activeKey) {
     alert(t('alerts.enter_api_key'));
@@ -94,8 +121,10 @@ export function saveSettings(): void {
   // Save keys
   state.apiKeyReplicate = replicateKey;
   state.apiKeyGemini = geminiKey;
+  state.apiKeyOpenRouter = openrouterKey;
   localStorage.setItem('nano_api_key_replicate', replicateKey);
   localStorage.setItem('nano_api_key_gemini', geminiKey);
+  localStorage.setItem('nano_api_key_openrouter', openrouterKey);
 
   // Update active key shortcut
   state.apiKey = activeKey;
@@ -1040,30 +1069,32 @@ function clearRemix(): void {
 /* --- PROVIDER-DEPENDENT UI --- */
 export function updateProviderDependentUI(): void {
   const isGemini = state.provider === 'gemini';
+  const isOpenRouter = state.provider === 'openrouter';
+  const isNonReplicate = isGemini || isOpenRouter;
 
-  // Hide format select for Gemini (PNG only)
+  // Hide format select for Gemini and OpenRouter (PNG only)
   const formatGroup = document.getElementById('formatSelect')?.closest('.setting-group') as HTMLElement | null;
   if (formatGroup) {
-    formatGroup.style.display = isGemini ? 'none' : '';
+    formatGroup.style.display = isNonReplicate ? 'none' : '';
   }
 
-  // Hide match_input_image option for Gemini
+  // Hide match_input_image option for Gemini and OpenRouter
   const aspectRatioSelect = document.getElementById('aspectRatioSelect') as HTMLSelectElement | null;
   if (aspectRatioSelect) {
     const matchOption = aspectRatioSelect.querySelector('option[value="match_input_image"]') as HTMLOptionElement | null;
     if (matchOption) {
-      matchOption.style.display = isGemini ? 'none' : '';
+      matchOption.style.display = isNonReplicate ? 'none' : '';
       // If currently selected, switch to 16:9
-      if (isGemini && aspectRatioSelect.value === 'match_input_image') {
+      if (isNonReplicate && aspectRatioSelect.value === 'match_input_image') {
         aspectRatioSelect.value = '16:9';
       }
     }
   }
 
-  // Hide resolution select for Gemini (not applicable)
+  // Hide resolution select for Gemini and OpenRouter (not applicable)
   const resolutionGroup = document.getElementById('resolutionSelect')?.closest('.setting-group') as HTMLElement | null;
   if (resolutionGroup) {
-    resolutionGroup.style.display = isGemini ? 'none' : '';
+    resolutionGroup.style.display = isNonReplicate ? 'none' : '';
   }
 }
 

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -221,7 +221,17 @@ export async function addToHistory(prompt: string, url: string, base64Data?: str
     state.history.splice(indexToRemove, 1);
   }
 
-  localStorage.setItem('nano_history', JSON.stringify(state.history));
+  // Prepare history for localStorage (strip large base64 data to prevent quota exceeded)
+  const historyForStorage = state.history.map(item => {
+    const storageItem = { ...item };
+    // If url contains base64 data (data:image), replace with placeholder to save space
+    if (storageItem.url && storageItem.url.startsWith('data:')) {
+      storageItem.url = `[STORED_IN_INDEXEDDB_${storageItem.localId || 'local'}]`;
+    }
+    return storageItem;
+  });
+
+  localStorage.setItem('nano_history', JSON.stringify(historyForStorage));
   renderHistory();
 }
 

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -1091,10 +1091,10 @@ export function updateProviderDependentUI(): void {
     }
   }
 
-  // Hide resolution select for Gemini and OpenRouter (not applicable)
+  // Hide resolution select for Gemini (not applicable)
   const resolutionGroup = document.getElementById('resolutionSelect')?.closest('.setting-group') as HTMLElement | null;
   if (resolutionGroup) {
-    resolutionGroup.style.display = isNonReplicate ? 'none' : '';
+    resolutionGroup.style.display = isGemini ? 'none' : '';
   }
 }
 


### PR DESCRIPTION
human note: tested a couple of times. works nicely.

This pull request adds support for OpenRouter as a third image generation provider alongside Replicate and Google Gemini. The changes update both the application logic and the user interface to allow users to select OpenRouter, provide an API key, and generate images via this new provider. Documentation and internationalization strings are also updated to reflect the addition of OpenRouter.

**OpenRouter Integration:**

* Added OpenRouter as a selectable provider in the settings modal, including a new input group for the API key and relevant help text and links. (`src/components/app/SettingsModal.astro`) [[1]](diffhunk://#diff-23aa96c811a801ac0c2402c32c9411ba73b0338b2eaeb9f5b623a72e738185f7R14) [[2]](diffhunk://#diff-23aa96c811a801ac0c2402c32c9411ba73b0338b2eaeb9f5b623a72e738185f7R35-R43)
* Updated the API integration logic to handle image generation via OpenRouter, following a synchronous single-request flow similar to Gemini. (`src/scripts/api.ts`) [[1]](diffhunk://#diff-bee7eddf5267c50e3abc9d0b96326137993f615be5d05bf62478430e1659c8afR6) [[2]](diffhunk://#diff-bee7eddf5267c50e3abc9d0b96326137993f615be5d05bf62478430e1659c8afR98-R121)
* Allowed requests to OpenRouter in the Netlify proxy function by adding its domain to the CORS whitelist. (`netlify/functions/replicate-proxy.ts`)

**Documentation and User Guidance:**

* Updated the `README.md` to mention OpenRouter throughout, including setup instructions, feature lists, and architecture overview. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L25-R25) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L60-R60) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L81-R81) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L128-R129)
* Modified English and French language files to include OpenRouter in all relevant descriptions, badges, FAQs, and footer text. (`src/scripts/i18n/en.ts`, `src/scripts/i18n/fr.ts`) [[1]](diffhunk://#diff-548021834e2299f9ceedb1d6b9f1843d33093953cf600791f2d9a92f9c48a8bbL19-R19) [[2]](diffhunk://#diff-548021834e2299f9ceedb1d6b9f1843d33093953cf600791f2d9a92f9c48a8bbL29-R29) [[3]](diffhunk://#diff-548021834e2299f9ceedb1d6b9f1843d33093953cf600791f2d9a92f9c48a8bbL57-R57) [[4]](diffhunk://#diff-548021834e2299f9ceedb1d6b9f1843d33093953cf600791f2d9a92f9c48a8bbL83-R83) [[5]](diffhunk://#diff-548021834e2299f9ceedb1d6b9f1843d33093953cf600791f2d9a92f9c48a8bbL105-R105) [[6]](diffhunk://#diff-548021834e2299f9ceedb1d6b9f1843d33093953cf600791f2d9a92f9c48a8bbR159-R164) [[7]](diffhunk://#diff-548021834e2299f9ceedb1d6b9f1843d33093953cf600791f2d9a92f9c48a8bbL223-R225) [[8]](diffhunk://#diff-17693a8beee068d5e8393f6b4a552ddd084845ebcb68e9c43e61bae91898f453L19-R19) [[9]](diffhunk://#diff-17693a8beee068d5e8393f6b4a552ddd084845ebcb68e9c43e61bae91898f453L29-R29) [[10]](diffhunk://#diff-17693a8beee068d5e8393f6b4a552ddd084845ebcb68e9c43e61bae91898f453L57-R57) [[11]](diffhunk://#diff-17693a8beee068d5e8393f6b4a552ddd084845ebcb68e9c43e61bae91898f453L83-R83) [[12]](diffhunk://#diff-17693a8beee068d5e8393f6b4a552ddd084845ebcb68e9c43e61bae91898f453L105-R105) [[13]](diffhunk://#diff-17693a8beee068d5e8393f6b4a552ddd084845ebcb68e9c43e61bae91898f453R159-R164) [[14]](diffhunk://#diff-17693a8beee068d5e8393f6b4a552ddd084845ebcb68e9c43e61bae91898f453L225-R227)

**UI/UX Improvements:**

* Improved handling of placeholder and generated image visibility with new `.hidden` classes in the main area styles for a smoother user experience. (`src/components/app/MainArea.astro`) [[1]](diffhunk://#diff-e67dfcfda544398f00c26258be412367ca8c3eecc2a9880b5c504b406bae1eeeL51-R71) [[2]](diffhunk://#diff-e67dfcfda544398f00c26258be412367ca8c3eecc2a9880b5c504b406bae1eeeL75-R99)